### PR TITLE
Mac test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vagrant

--- a/cvmfs/cloud_testing/Vagrantfile
+++ b/cvmfs/cloud_testing/Vagrantfile
@@ -1,0 +1,39 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # allow virtual box to take advantage of the host's speed
+  # Snippet found here (thanks to Stefan Wrobel):
+  # https://stefanwrobel.com/how-to-make-vagrant-performance-not-suck
+  config.vm.provider "virtualbox" do |v|
+    host = RbConfig::CONFIG['host_os']
+
+    # Give VM 1/4 system memory & access to all cpu cores on the host
+    if host =~ /darwin/
+      cpus = `sysctl -n hw.ncpu`.to_i
+      # sysctl returns Bytes and we need to convert to MB
+      mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
+    elsif host =~ /linux/
+      cpus = `nproc`.to_i
+      # meminfo shows KB and we need to convert to MB
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
+    else # sorry Windows folks, I can't help you
+      cpus = 2
+      mem = 1024
+    end
+
+    v.customize ["modifyvm", :id, "--memory", mem]
+    v.customize ["modifyvm", :id, "--cpus", cpus]
+  end
+
+  config.vm.define "yosemite" do |yosemite|
+    yosemite.vm.box = "yosemite"
+    yosemite.vm.network "private_network", ip: "192.168.33.15"
+    yosemite.vm.synced_folder '.', '/Users/vagrant/ci-scripts', nfs: true
+    yosemite.vm.provision "shell", path: "vagrant/provision_osx.sh"
+  end
+end

--- a/cvmfs/cloud_testing/Vagrantfile
+++ b/cvmfs/cloud_testing/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure(2) do |config|
   config.vm.define "yosemite" do |yosemite|
     yosemite.vm.box = "yosemite"
     yosemite.vm.network "private_network", ip: "192.168.33.15"
-    yosemite.vm.synced_folder '.', '/Users/vagrant/ci-scripts', nfs: true
+    yosemite.vm.synced_folder '.', '/Users/vagrant/ci-scripts', disabled: true
     yosemite.vm.provision "shell", path: "vagrant/provision_osx.sh"
   end
 end

--- a/cvmfs/cloud_testing/doc/README.md
+++ b/cvmfs/cloud_testing/doc/README.md
@@ -1,0 +1,21 @@
+# Instructions to launch the mac VM
+
+## Requirements for the mac host
+- Recommended Mac OSX 10.10 (yosemite).
+- Vagrant installed with the vagrant-scp plugin (vagrant plugin install vagrant-scp).
+- VirtualBox installed.
+- jq utility (prefereably 1.4) to parse JSON files.
+- If intended to be used with Jenkins create the user sftnight and grant him sudo without password.
+
+## VM instructions
+### Creation of the VM
+1) Download the corresponding .dmg official image from the apple store. It should be free having an apple ID, but older images are pretty difficult to find.
+2) Use the dmg file to spawn a mac VM inside a mac. You might need to enable EFI to access it.
+3) Access to the newly created mac VM through the GUI and create the 'vagrant' user and grant him access through ssh. Grant him sudo as well. Enable the ssh service too. Install hombrew and any other tool you might need, like *Xcode*. However, **it is recommendable not to install any unnecessary software**. It is better to do it in the provision step, where the software is updated.
+4) Exit the VM and pack it with vagrant. Follow the instructions in https://docs.vagrantup.com/v2/virtualbox/boxes.html.
+5) This generated box file can be imported later to Vagrant using the 'vagrant box add' command.
+
+### Usage of the .box file
+- **There is already a Mac OSX 10.10 Yosemite vagrant box ready to use in the private storage**. To import it simply type 'vagrant box add \<path-to-yosemite-box-file\> --name yosemite'.
+- After that you should be able to execute 'vagrant up yosemite && vagrant ssh yosemite' to enter in the recently booted machine. It is important to mention that it is necessary to be in the _ci-scripts/cvmfs/cloud_testing_ folder.
+- Also, the creation process will include a **provision** step defined in the ci-scripts/cvmfs/cloud_testing/vagrant/provision_osx.sh script. It should update brew to get the most updated software, and install the basic utilities. For example: wget, jq, fuse, etc.

--- a/cvmfs/cloud_testing/platforms.json
+++ b/cvmfs/cloud_testing/platforms.json
@@ -157,7 +157,7 @@
     "dist"    : "osx",
     "config"  : "x86_64",
     "ami"     : "yosemite",
-    "label"   : "osx.x86_64",
+    "label"   : "osx_x86_64",
     "setup"   : "osx_x86_64_setup.sh",
     "test"    : "osx_x86_64_test.sh",
     "user"    : "vagrant"

--- a/cvmfs/cloud_testing/platforms.json
+++ b/cvmfs/cloud_testing/platforms.json
@@ -141,6 +141,16 @@
     "setup"   : "fedora22_x86_64_setup.sh",
     "test"    : "fedora22_x86_64_test.sh",
     "user"    : "fedora"
+  },
+
+  {
+    "dist"    : "osx",
+    "config"  : "x86_64",
+    "ami"     : "yosemite",
+    "label"   : "osx.x86_64",
+    "setup"   : "osx_x86_64_setup.sh",
+    "test"    : "osx_x86_64_test.sh",
+    "user"    : "vagrant"
   }
 
 ]

--- a/cvmfs/cloud_testing/platforms.json
+++ b/cvmfs/cloud_testing/platforms.json
@@ -88,9 +88,7 @@
     "setup"   : "centos7_x86_64_setup.sh",
     "test"    : "centos7_x86_64_test.sh",
     "user"    : "centos",
-    "context" : "#!/bin/sh
-                 echo 'Defaults !requiretty' | tee --append /etc/sudoers
-                 echo 'Defaults visiblepw' | tee --append /etc/sudoers"
+    "context" : "#!/bin/sh \\n echo 'Defaults !requiretty' | tee --append /etc/sudoers \\n echo 'Defaults visiblepw' | tee --append /etc/sudoers"
   },
 
   {

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # This script spawns a virtual machine of a specific platform type on ibex and
-# runs the associated test cases on this machine
+# runs the associated test cases on this machine.
+# Some variables have been sourced in ../run_cloudtests.sh
 
 # Configuration for cloud access
 # Example:
@@ -17,11 +18,7 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common.sh
 
 config_package_base_url="https://ecsft.cern.ch/dist/cvmfs/cvmfs-config"
-
-# static information (check also remote_setup.sh and remote_run.sh)
-cvmfs_workspace="/tmp/cvmfs-test-workspace"
 cvmfs_source_directory="${cvmfs_workspace}/cvmfs-source"
-cvmfs_log_directory="${cvmfs_workspace}/logs"
 
 # global variables (get filled by spawn_virtual_machine)
 ip_address=""

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -18,7 +18,7 @@ script_location=$(cd "$(dirname "$0")"; pwd)
 . ${script_location}/common.sh
 
 config_package_base_url="https://ecsft.cern.ch/dist/cvmfs/cvmfs-config"
-cvmfs_source_directory="${cvmfs_workspace}/cvmfs-source"
+cvmfs_source_directory="${CT_CVMFS_WORKSPACE}/cvmfs-source"
 
 # global variables (get filled by spawn_virtual_machine)
 ip_address=""
@@ -81,17 +81,17 @@ setup_virtual_machine() {
   remote_setup_script="${script_location}/remote_setup.sh"
 
   echo -n "setting up VM ($ip) for CernVM-FS test suite... "
-  run_script_on_virtual_machine $ip $username $remote_setup_script \
-      -s $server_package                                           \
-      -c $client_package                                           \
-      -d $devel_package                                            \
-      -t $source_tarball                                           \
-      -g $unittest_package                                         \
-      -k "$config_packages"                                        \
-      -r $platform_setup_script
+  run_script_on_virtual_machine $ip $CT_USERNAME $remote_setup_script \
+      -s $server_package                                              \
+      -c $client_package                                              \
+      -d $devel_package                                               \
+      -t $source_tarball                                              \
+      -g $unittest_package                                            \
+      -k "$config_packages"                                           \
+      -r $CT_PLATFORM_setup_script
   check_retcode $?
   if [ $? -ne 0 ]; then
-    handle_test_failure $ip $username
+    handle_test_failure $ip $CT_USERNAME
     return 1
   fi
 
@@ -110,16 +110,16 @@ run_test_cases() {
   remote_run_script="${script_location}/remote_run.sh"
 
   echo -n "running test cases on VM ($ip)... "
-  run_script_on_virtual_machine $ip $username $remote_run_script \
+  run_script_on_virtual_machine $ip $CT_USERNAME $remote_run_script \
       -s $server_package                                         \
       -c $client_package                                         \
       -d $devel_package                                          \
       -k "$config_packages"                                      \
-      -r $platform_run_script
+      -r $CT_PLATFORM_run_script
   check_retcode $?
 
   if [ $? -ne 0 ]; then
-    handle_test_failure $ip $username
+    handle_test_failure $ip $CT_USERNAME
   fi
 }
 
@@ -128,7 +128,7 @@ handle_test_failure() {
   local ip=$1
   local username=$2
 
-  get_test_results $ip $username
+  get_test_results $ip $CT_USERNAME
 
   echo "at least one test case failed... skipping destructions of VM!"
   exit 100
@@ -144,7 +144,7 @@ get_test_results() {
   retrieve_file_from_virtual_machine \
       $ip                            \
       $username                      \
-      "${cvmfs_log_directory}/*"     \
+      "${CT_CVMFS_LOG_DIRECTORY}/*"  \
       $log_destination
   check_retcode $?
 }
@@ -155,29 +155,29 @@ get_test_results() {
 #
 
 # check if we have all bits and pieces
-if [ x$platform_run_script   = "x" ] ||
-   [ x$platform_setup_script = "x" ] ||
-   [ x$platform              = "x" ] ||
-   [ x$testee_url            = "x" ] ||
-   [ x$ami_name              = "x" ]; then
+if [ x$CT_PLATFORM_RUN_SCRIPT   = "x" ] ||
+   [ x$CT_PLATFORM_SETUP_SCRIPT = "x" ] ||
+   [ x$CT_PLATFORM              = "x" ] ||
+   [ x$CT_TESTEE_URL            = "x" ] ||
+   [ x$CT_AMI_NAME              = "x" ]; then
   usage "Missing parameter(s)"
 fi
 
 # check if we have a custom client testee URL
-if [ ! -z "$client_testee_url" ]; then
+if [ ! -z "$CT_CLIENT_TESTEE_URL" ]; then
   echo "using custom client from here: $client_testee_url"
 else
   client_testee_url="$testee_url"
 fi
 
 # figure out which packages need to be downloaded
-ctu="$client_testee_url"
-otu="$testee_url"
-client_package=$(read_package_map   ${ctu}/pkgmap "$platform" 'client'   )
-server_package=$(read_package_map   ${otu}/pkgmap "$platform" 'server'   )
-devel_package=$(read_package_map    ${ctu}/pkgmap "$platform" 'devel'    )
-unittest_package=$(read_package_map ${otu}/pkgmap "$platform" 'unittests')
-config_packages="$(read_package_map ${otu}/pkgmap "$platform" 'config'   )"
+ctu="$CT_CLIENT_TESTEE_URL"
+otu="$CT_TESTEE_URL"
+client_package=$(read_package_map   ${ctu}/pkgmap "$CT_PLATFORM" 'client'   )
+server_package=$(read_package_map   ${otu}/pkgmap "$CT_PLATFORM" 'server'   )
+devel_package=$(read_package_map    ${ctu}/pkgmap "$CT_PLATFORM" 'devel'    )
+unittest_package=$(read_package_map ${otu}/pkgmap "$CT_PLATFORM" 'unittests')
+config_packages="$(read_package_map ${otu}/pkgmap "$CT_PLATFORM" 'config'   )"
 
 # check if all necessary packages were found
 if [ x"$server_package"        = "x" ] ||
@@ -193,7 +193,7 @@ client_package="${ctu}/${client_package}"
 server_package="${otu}/${server_package}"
 devel_package="${ctu}/${devel_package}"
 unittest_package="${otu}/${unittest_package}"
-source_tarball="${otu}/${source_tarball}"
+source_tarball="${otu}/${CT_SOURCE_TARBALL}"
 config_package_urls=""
 for config_package in $config_packages; do
   config_package_urls="${config_package_base_url}/${config_package} $config_package_urls"
@@ -206,12 +206,12 @@ config_packages="$config_package_urls"
 # spawn the virtual machine image, run the platform specific setup script
 # on it, wait for the spawning and setup to be complete and run the actual
 # test suite on the VM.
-spawn_my_virtual_machine  $ami_name   "$userdata" || die "Aborting..."
-wait_for_virtual_machine  $ip_address  $username  || die "Aborting..."
-setup_virtual_machine     $ip_address  $username  || die "Aborting..."
-wait_for_virtual_machine  $ip_address  $username  || die "Aborting..."
-run_test_cases            $ip_address  $username  || die "Aborting..."
-get_test_results          $ip_address  $username  || die "Aborting..."
-tear_down_virtual_machine $instance_id            || die "Aborting..."
+spawn_my_virtual_machine  $CT_AMI_NAME "$CT_USERDATA"   || die "Aborting..."
+wait_for_virtual_machine  $ip_address   $CT_USERNAME    || die "Aborting..."
+setup_virtual_machine     $ip_address   $CT_USERNAME    || die "Aborting..."
+wait_for_virtual_machine  $ip_address   $CT_USERNAME    || die "Aborting..."
+run_test_cases            $ip_address   $CT_USERNAME    || die "Aborting..."
+get_test_results          $ip_address   $CT_USERNAME    || die "Aborting..."
+tear_down_virtual_machine $instance_id                  || die "Aborting..."
 
 echo "all done"

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -122,6 +122,11 @@ setup_virtual_machine() {
   echo "done"
 }
 
+is_linux_vm() {
+  local ami=$1
+  echo "$ami" | grep -E "^ami-[0-9a-zA-Z]+$"
+  [ $? -eq 0 ]
+}
 
 run_test_cases() {
   local ip=$1
@@ -241,6 +246,12 @@ server_package=$(read_package_map   ${otu}/pkgmap "$platform" 'server'   )
 devel_package=$(read_package_map    ${ctu}/pkgmap "$platform" 'devel'    )
 unittest_package=$(read_package_map ${otu}/pkgmap "$platform" 'unittests')
 config_packages="$(read_package_map ${otu}/pkgmap "$platform" 'config'   )"
+
+# if we are on mac then we have to run an special script
+if [ ! $(is_linux_vm $ami_name) ]; then
+  $script_location/run_mac.sh $otu $client_package $source_tarball $ami_name $platform_setup_script $platform_run_script
+  exit $?
+fi
 
 # check if all necessary packages were found
 if [ x"$server_package"        = "x" ] ||

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -30,7 +30,7 @@ log_destination="."
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
 
-
+set -x
 
 usage() {
   local msg="$1"
@@ -145,9 +145,9 @@ fi
 
 # check if we have a custom client testee URL
 if [ ! -z "$CT_CLIENT_TESTEE_URL" ]; then
-  echo "using custom client from here: $client_testee_url"
+  echo "using custom client from here: $CT_CLIENT_TESTEE_URL"
 else
-  client_testee_url="$testee_url"
+  export CT_CLIENT_TESTEE_URL="$CT_TESTEE_URL"
 fi
 
 # figure out which packages need to be downloaded
@@ -181,7 +181,7 @@ done
 config_packages="$config_package_urls"
 
 # load EC2 configuration
-. $ec2_config
+. $CT_EC2_CONFIG
 
 # spawn the virtual machine image, run the platform specific setup script
 # on it, wait for the spawning and setup to be complete and run the actual

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -68,7 +68,7 @@ setup_virtual_machine() {
       -s $server_package                                              \
       -c $client_package                                              \
       -d $devel_package                                               \
-      -t $CT_SOURCE_TARBALL                                           \
+      -t $source_tarball                                              \
       -g $unittest_package                                            \
       -k "$config_packages"                                           \
       -r $CT_PLATFORM_SETUP_SCRIPT
@@ -92,11 +92,11 @@ run_test_cases() {
   remote_run_script="${script_location}/remote_run.sh"
 
   echo -n "running test cases on VM ($ip)... "
-  run_script_on_virtual_machine $ip $CT_USERNAME $remote_run_script \
-      -s $server_package                                         \
-      -c $client_package                                         \
-      -d $devel_package                                          \
-      -k "$config_packages"                                      \
+  run_script_on_virtual_machine $ip $CT_USERNAME $remote_run_script   \
+      -s $server_package                                              \
+      -c $client_package                                              \
+      -d $devel_package                                               \
+      -k "$config_packages"                                           \
       -r $CT_PLATFORM_RUN_SCRIPT
   check_retcode $?
 

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -46,9 +46,9 @@ spawn_my_virtual_machine() {
 
   local retcode
 
-  echo -n "spawning virtual machine from $ami... "
+  echo -n "spawning virtual machine from $CT_AMI_NAME... "
   local spawn_results
-  spawn_results="$(spawn_virtual_machine $ami "$userdata")"
+  spawn_results="$(spawn_virtual_machine $CT_AMI_NAME "$CT_USERDATA")"
   retcode=$?
   instance_id=$(echo $spawn_results | awk '{print $1}')
   ip_address=$(echo $spawn_results | awk '{print $2}')
@@ -68,7 +68,7 @@ setup_virtual_machine() {
       -s $server_package                                              \
       -c $client_package                                              \
       -d $devel_package                                               \
-      -t $source_tarball                                              \
+      -t $CT_SOURCE_TARBALL                                           \
       -g $unittest_package                                            \
       -k "$config_packages"                                           \
       -r $CT_PLATFORM_SETUP_SCRIPT

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -26,6 +26,7 @@ cvmfs_log_directory="${cvmfs_workspace}/logs"
 # global variables (get filled by spawn_virtual_machine)
 ip_address=""
 instance_id=""
+log_destination="."
 
 
 #

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -36,22 +36,6 @@ usage() {
   local msg="$1"
 
   echo "Error: $msg"
-  echo
-  echo "Mandatory options:"
-  echo " -u <testee URL>            URL to the nightly build directory to be tested"
-  echo " -p <platform name>         name of the platform to be tested"
-  echo " -b <setup script>          platform specific setup script (inside the tarball)"
-  echo " -r <run script>            platform specific test script (inside the tarball)"
-  echo " -a <AMI name>              the virtual machine image to spawn"
-  echo
-  echo "Optional parameters:"
-  echo " -e <EC2 config file>       local location of the ec2_config.sh file"
-  echo " -d <results destination>   Directory to store final test session logs"
-  echo " -m <ssh user name>         User name to be used for VM login (default: root)"
-  echo " -c <cloud init userdata>   User data string to be passed to the new instance"
-  echo
-  echo " -l <custom client URL>     URL to a nightly build for a custom CVMFS client"
-
   exit 1
 }
 

--- a/cvmfs/cloud_testing/run.sh
+++ b/cvmfs/cloud_testing/run.sh
@@ -75,7 +75,6 @@ spawn_my_virtual_machine() {
 
 setup_virtual_machine() {
   local ip=$1
-  local username=$2
 
   local remote_setup_script
   remote_setup_script="${script_location}/remote_setup.sh"
@@ -88,7 +87,7 @@ setup_virtual_machine() {
       -t $source_tarball                                              \
       -g $unittest_package                                            \
       -k "$config_packages"                                           \
-      -r $CT_PLATFORM_setup_script
+      -r $CT_PLATFORM_SETUP_SCRIPT
   check_retcode $?
   if [ $? -ne 0 ]; then
     handle_test_failure $ip $CT_USERNAME
@@ -102,7 +101,6 @@ setup_virtual_machine() {
 
 run_test_cases() {
   local ip=$1
-  local username=$2
 
   local retcode
   local log_files
@@ -115,7 +113,7 @@ run_test_cases() {
       -c $client_package                                         \
       -d $devel_package                                          \
       -k "$config_packages"                                      \
-      -r $CT_PLATFORM_run_script
+      -r $CT_PLATFORM_RUN_SCRIPT
   check_retcode $?
 
   if [ $? -ne 0 ]; then
@@ -126,7 +124,6 @@ run_test_cases() {
 
 handle_test_failure() {
   local ip=$1
-  local username=$2
 
   get_test_results $ip $CT_USERNAME
 
@@ -137,13 +134,12 @@ handle_test_failure() {
 
 get_test_results() {
   local ip=$1
-  local username=$2
   local retval=0
 
   echo -n "retrieving test results... "
   retrieve_file_from_virtual_machine \
       $ip                            \
-      $username                      \
+      $CT_USERNAME                   \
       "${CT_CVMFS_LOG_DIRECTORY}/*"  \
       $log_destination
   check_retcode $?

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -2,26 +2,11 @@
 
 # in this script we will sum up all the different steps to run the tests
 # on a mac VM from a mac host
-usage() {
-  local msg="$1"
-
-  echo "Error: $msg"
-  echo "Usage: $0 <testee_url> <package_name> <source_name> <osx_name> <setup_script> <run_script>"
-  echo
-  echo " <testee_url>            URL to the nightly build directory to be tested"
-  echo " <package_name>          Name of the mac package to install"
-  echo " <source_name>           Name of the source file"
-  echo " <osx_name>              Name of the OSX. Can be yosemite, el_capitan, etc."
-  echo " <setup_script>          Name of the setup_script for mac"
-  echo " <run_script>            Name of the run_script for mac"
-
-  exit 1
-}
 
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 cd "$SCRIPT_LOCATION"
-
+set -x
 testee_url=$1
 package_name=$2
 source_name=$3
@@ -32,24 +17,26 @@ client_package_url="$testee_url/$package_name"
 source_tarball_url="$testee_url/$source_name"
 
 # Step 0: check the things are there
-which vagrant                           || usage "Vagrant is not installed!"
-vagrant plugin list | grep vagrant-scp  || usage "Vagrant scp plugin not installed!"
+which vagrant                           || echo "Vagrant is not installed!"
+vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
-vagrant up $osx_name || usage "Cannot execute vagrant up $osx_name"
+vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
 
-# Step 2: download and decompress the sources and install the client
-vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || usage "Couldn't download and decompress the sources in the mac VM"
-vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || usage "Couldn't download and install the CVMFS package"
+# Step 2: run the script
+vagrant ssh -c "
+export testee_url=$1
+export package_name=$2
+export source_name=$3
+export osx_name=$4  # might be yosemite, el_capitan, etc.
+export setup_script=$5
+export run_script=$6
+export client_package_url="$testee_url/$package_name"
+export source_tarball_url="$testee_url/$source_name"
+bash -s" < run_remote_mac.sh $osx_name
 
-# Step 3: run the setup script
-vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$setup_script" $osx_name || usage "Couldn't execute the setup_script"
-
-# Step 4: run the test script
-vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$run_script" $osx_name
-
-# Step 5: destroy the VM
-if [ $retval -eq 0 ]; then
+# Step 3: destroy the VM
+if [ $? -eq 0 ]; then
   vagrant destroy -f $osx_name
 else
   echo "VM not destroyed because the tests failed. Access to the VM by running 'vagrant ssh $osx_name' from the host machine"

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -8,7 +8,7 @@
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 cd "$SCRIPT_LOCATION"
 . ${SCRIPT_LOCATION}/common.sh
-
+set -x
 log_destination="."
 osx_name="$ami_name"
 package_name=$(read_package_map   ${testee_url}/pkgmap "$platform" 'client')

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -2,37 +2,36 @@
 
 # in this script we will sum up all the different steps to run the tests
 # on a mac VM from a mac host
+# All the variables are defined in ../run_cloudtests.sh
 
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 cd "$SCRIPT_LOCATION"
+. ${SCRIPT_LOCATION}/common.sh
 set -x
-testee_url=$1
-package_name=$2
-source_name=$3
-osx_name=$4  # might be yosemite, el_capitan, etc.
-setup_script=$5
-run_script=$6
+
+package_name=$(read_package_map   ${testee_url}/pkgmap "$platform" 'client'   )
 client_package_url="$testee_url/$package_name"
-source_tarball_url="$testee_url/$source_name"
+source_tarball_url="$testee_url/$source_tarball"
 
 # Step 0: check the things are there
 which vagrant                           || echo "Vagrant is not installed!"
 vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
+osx_name=$ami_name
 vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
 
 # Step 2: run the script
 vagrant ssh -c "
-export testee_url=$1
-export package_name=$2
-export source_name=$3
-export osx_name=$4  # might be yosemite, el_capitan, etc.
-export setup_script=$5
-export run_script=$6
-export client_package_url="$testee_url/$package_name"
-export source_tarball_url="$testee_url/$source_name"
+export testee_url=$testee_url
+export package_name=$package_name
+export source_name=$source_tarball
+export osx_name=$osx_name
+export setup_script=$platform_setup_script
+export run_script=$platform_run_script
+export client_package_url=$client_package_url
+export source_tarball_url=$source_tarball_url
 bash -s" < run_remote_mac.sh $osx_name
 
 # Step 3: destroy the VM

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -8,9 +8,10 @@
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 cd "$SCRIPT_LOCATION"
 . ${SCRIPT_LOCATION}/common.sh
-set -x
 
-package_name=$(read_package_map   ${testee_url}/pkgmap "$platform" 'client'   )
+log_destination="."
+osx_name="$ami_name"
+package_name=$(read_package_map   ${testee_url}/pkgmap "$platform" 'client')
 client_package_url="$testee_url/$package_name"
 source_tarball_url="$testee_url/$source_tarball"
 
@@ -19,7 +20,6 @@ which vagrant                           || echo "Vagrant is not installed!"
 vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
-osx_name=$ami_name
 vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
 
 # Step 2: run the script
@@ -32,10 +32,19 @@ export setup_script=$platform_setup_script
 export run_script=$platform_run_script
 export client_package_url=$client_package_url
 export source_tarball_url=$source_tarball_url
+
+export cvmfs_workspace=$cvmfs_workspace
+export cvmfs_log_directory=$cvmfs_workspace/logs
+
 bash -s" < run_remote_mac.sh $osx_name
 
-# Step 3: destroy the VM
-if [ $? -eq 0 ]; then
+retval=$?
+
+# Step 3: Collect the results
+vagrant scp "$osx_name:$cvmfs_log_directory/*" "$log_destination"
+
+# Step 4: destroy the VM if everything was correct
+if [ $retval -eq 0 ]; then
   vagrant destroy -f $osx_name
 else
   echo "VM not destroyed because the tests failed. Access to the VM by running 'vagrant ssh $osx_name' from the host machine"

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -x
+# in this script we will sum up all the different steps to run the tests
+# on a mac VM from a mac host
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+cd "$SCRIPT_LOCATION"
+
+testee_url=$1
+package_name=$2
+source_name=$3
+osx_name=$4  # might be yosemite, el_capitan, etc.
+setup_script=$5
+run_script=$6
+client_package_url="$testee_url/$package_name"
+source_tarball_url="$testee_url/$source_name"
+
+# Step 0: check the things are there
+which vagrant                           || echo "Vagrant is not installed!"
+vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
+
+# Step 1: boot the VM
+vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
+
+# Step 2: download and decompress the sources and install the client
+vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || echo "Couldn't download and decompress the sources in the mac VM"
+vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || echo "Couldn't download and install the CVMFS package"
+
+# Step 3: run the setup script
+vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$setup_script" $osx_name
+
+# Step 4: run the test script
+vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$run_script" $osx_name
+
+# Step 5: destroy the VM
+#vagrant destroy -f $osx_name

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -16,15 +16,15 @@ client_package_url="$testee_url/$package_name"
 source_tarball_url="$testee_url/$source_name"
 
 # Step 0: check the things are there
-which vagrant                           || die "Vagrant is not installed!"
-vagrant plugin list | grep vagrant-scp  || die "Vagrant scp plugin not installed!"
+which vagrant                           || echo "Vagrant is not installed!"
+vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
-vagrant up $osx_name || die "Cannot execute vagrant up $osx_name"
+vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
 
 # Step 2: download and decompress the sources and install the client
-vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || die "Couldn't download and decompress the sources in the mac VM"
-vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || die "Couldn't download and install the CVMFS package"
+vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || echo "Couldn't download and decompress the sources in the mac VM"
+vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || echo "Couldn't download and install the CVMFS package"
 
 # Step 3: run the setup script
 vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$setup_script" $osx_name

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -2,7 +2,7 @@
 
 # in this script we will sum up all the different steps to run the tests
 # on a mac VM from a mac host
-# All the variables are defined in ../run_cloudtests.sh
+# All CT_* global variables are defined in ../run_cloudtests.sh
 
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
@@ -10,10 +10,10 @@ cd "$SCRIPT_LOCATION"
 . ${SCRIPT_LOCATION}/common.sh
 
 log_destination="."
-osx_name="$ami_name"
-package_name=$(read_package_map   ${testee_url}/pkgmap "$platform" 'client')
-client_package_url="$testee_url/$package_name"
-source_tarball_url="$testee_url/$source_tarball"
+osx_name="$CT_AMI_NAME"
+package_name=$(read_package_map   ${CT_TESTEE_URL}/pkgmap "$CT_PLATFORM" 'client')
+client_package_url="$CT_TESTEE_URL/$package_name"
+source_tarball_url="$CT_TESTEE_URL/$CT_SOURCE_TARBALL"
 
 # Step 0: check the things are there
 which vagrant                           || echo "Vagrant is not installed!"
@@ -23,19 +23,21 @@ vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installe
 vagrant destroy -f $osx_name || echo "There are no Vagrant VMs. Creating one"  # just in case it's still there
 vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
 
+cvmfs_log_directory="$CT_CVMFS_WORKSPACE/logs"
+
 # Step 2: run the script
 vagrant ssh -c "
-export testee_url=$testee_url
+export CT_TESTEE_URL=$CT_TESTEE_URL
 export package_name=$package_name
-export source_name=$source_tarball
+export CT_SOURCE_TARBALL=$CT_SOURCE_TARBALL
 export osx_name=$osx_name
-export setup_script=$platform_setup_script
-export run_script=$platform_run_script
+export CT_PLATFORM_SETUP_SCRIPT=$CT_PLATFORM_SETUP_SCRIPT
+export CT_PLATFORM_RUN_SCRIPT=$CT_PLATFORM_RUN_SCRIPT
 export client_package_url=$client_package_url
 export source_tarball_url=$source_tarball_url
 
-export cvmfs_workspace=$cvmfs_workspace
-export cvmfs_log_directory=$cvmfs_workspace/logs
+export CT_CVMFS_WORKSPACE=$CT_CVMFS_WORKSPACE
+export cvmfs_log_directory=$cvmfs_log_directory
 
 bash -s" < run_remote_mac.sh $osx_name
 
@@ -50,3 +52,5 @@ if [ $retval -eq 0 ]; then
 else
   echo "VM not destroyed because the tests failed. Access to the VM by running 'vagrant ssh $osx_name' from the host machine"
 fi
+
+exit $retval

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -20,6 +20,7 @@ which vagrant                           || echo "Vagrant is not installed!"
 vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
+vagrant destroy -f $osx_name || echo "There are no Vagrant VMs. Creating one"  # just in case it's still there
 vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
 
 # Step 2: run the script

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -1,8 +1,24 @@
 #!/bin/bash
 
-set -x
 # in this script we will sum up all the different steps to run the tests
 # on a mac VM from a mac host
+usage() {
+  local msg="$1"
+
+  echo "Error: $msg"
+  echo "Usage: $0 <testee_url> <package_name> <source_name> <osx_name> <setup_script> <run_script>"
+  echo
+  echo " <testee_url>            URL to the nightly build directory to be tested"
+  echo " <package_name>          Name of the mac package to install"
+  echo " <source_name>           Name of the source file"
+  echo " <osx_name>              Name of the OSX. Can be yosemite, el_capitan, etc."
+  echo " <setup_script>          Name of the setup_script for mac"
+  echo " <run_script>            Name of the run_script for mac"
+
+  exit 1
+}
+
+
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 cd "$SCRIPT_LOCATION"
 
@@ -16,19 +32,18 @@ client_package_url="$testee_url/$package_name"
 source_tarball_url="$testee_url/$source_name"
 
 # Step 0: check the things are there
-which vagrant                           || echo "Vagrant is not installed!"
-vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
+which vagrant                           || usage "Vagrant is not installed!"
+vagrant plugin list | grep vagrant-scp  || usage "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
-vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
+vagrant up $osx_name || usage "Cannot execute vagrant up $osx_name"
 
 # Step 2: download and decompress the sources and install the client
-vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || echo "Couldn't download and decompress the sources in the mac VM"
-vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || echo "Couldn't download and install the CVMFS package"
+vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || usage "Couldn't download and decompress the sources in the mac VM"
+vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || usage "Couldn't download and install the CVMFS package"
 
 # Step 3: run the setup script
-vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$setup_script" $osx_name
-retval=$?
+vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$setup_script" $osx_name || usage "Couldn't execute the setup_script"
 
 # Step 4: run the test script
 vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$run_script" $osx_name

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -8,7 +8,7 @@
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 cd "$SCRIPT_LOCATION"
 . ${SCRIPT_LOCATION}/common.sh
-set -x
+
 log_destination="."
 osx_name="$ami_name"
 package_name=$(read_package_map   ${testee_url}/pkgmap "$platform" 'client')

--- a/cvmfs/cloud_testing/run_mac.sh
+++ b/cvmfs/cloud_testing/run_mac.sh
@@ -16,21 +16,26 @@ client_package_url="$testee_url/$package_name"
 source_tarball_url="$testee_url/$source_name"
 
 # Step 0: check the things are there
-which vagrant                           || echo "Vagrant is not installed!"
-vagrant plugin list | grep vagrant-scp  || echo "Vagrant scp plugin not installed!"
+which vagrant                           || die "Vagrant is not installed!"
+vagrant plugin list | grep vagrant-scp  || die "Vagrant scp plugin not installed!"
 
 # Step 1: boot the VM
-vagrant up $osx_name || echo "Cannot execute vagrant up $osx_name"
+vagrant up $osx_name || die "Cannot execute vagrant up $osx_name"
 
 # Step 2: download and decompress the sources and install the client
-vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || echo "Couldn't download and decompress the sources in the mac VM"
-vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || echo "Couldn't download and install the CVMFS package"
+vagrant ssh -c "wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs" $osx_name || die "Couldn't download and decompress the sources in the mac VM"
+vagrant ssh -c "wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target /" $osx_name || die "Couldn't download and install the CVMFS package"
 
 # Step 3: run the setup script
 vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$setup_script" $osx_name
+retval=$?
 
 # Step 4: run the test script
 vagrant ssh -c "cvmfs/test/cloud_testing/platforms/$run_script" $osx_name
 
 # Step 5: destroy the VM
-#vagrant destroy -f $osx_name
+if [ $retval -eq 0 ]; then
+  vagrant destroy -f $osx_name
+else
+  echo "VM not destroyed because the tests failed. Access to the VM by running 'vagrant ssh $osx_name' from the host machine"
+fi

--- a/cvmfs/cloud_testing/run_remote_mac.sh
+++ b/cvmfs/cloud_testing/run_remote_mac.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+usage() {
+  local msg="$1"
+
+  echo "Error: $msg"
+  echo "Usage: $0 <testee_url> <package_name> <source_name> <osx_name> <setup_script> <run_script>"
+  echo
+  echo " <testee_url>            URL to the nightly build directory to be tested"
+  echo " <package_name>          Name of the mac package to install"
+  echo " <source_name>           Name of the source file"
+  echo " <osx_name>              Name of the OSX. Can be yosemite, el_capitan, etc."
+  echo " <setup_script>          Name of the setup_script for mac"
+  echo " <run_script>            Name of the run_script for mac"
+
+  exit 1
+}
+set -x
+echo "Printing environment " && env
+
+original_directory=$(pwd)
+
+# Download and decompress the sources and install the client
+wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs || usage "Couldn't download and decompress the sources in the mac VM"
+wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target / && cd $original_directory || usage "Couldn't download and install the CVMFS package"
+
+# Run the setup script
+cvmfs/test/cloud_testing/platforms/$setup_script $osx_name || usage "Couldn't execute the setup_script"
+
+# Run the test script
+cvmfs/test/cloud_testing/platforms/$run_script $osx_name || usage "Couldn't execute the run_script"

--- a/cvmfs/cloud_testing/run_remote_mac.sh
+++ b/cvmfs/cloud_testing/run_remote_mac.sh
@@ -1,34 +1,22 @@
 #!/bin/bash
 
-usage() {
+error() {
   local msg="$1"
-
   echo "Error: $msg"
-  echo "Usage: $0 <testee_url> <package_name> <source_name> <osx_name> <setup_script> <run_script>"
-  echo
-  echo " <testee_url>            URL to the nightly build directory to be tested"
-  echo " <package_name>          Name of the mac package to install"
-  echo " <source_name>           Name of the source file"
-  echo " <osx_name>              Name of the OSX. Can be yosemite, el_capitan, etc."
-  echo " <setup_script>          Name of the setup_script for mac"
-  echo " <run_script>            Name of the run_script for mac"
-
   exit 1
 }
-set -x
-echo "Printing environment " && env
 
 original_directory=$(pwd)
 
 # Create the workspace and the log directories
-mkdir -p "$cvmfs_workspace" "$cvmfs_log_directory"
+mkdir -p "$CT_CVMFS_WORKSPACE" "$cvmfs_log_directory"
 
 # Download and decompress the sources and install the client
-wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs || usage "Couldn't download and decompress the sources in the mac VM"
-wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target / && cd $original_directory || usage "Couldn't download and install the CVMFS package"
+wget $source_tarball_url && tar xvf $CT_SOURCE_TARBALL && mv cvmfs* cvmfs || error "Couldn't download and decompress the sources in the mac VM"
+wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target / && cd $original_directory || error "Couldn't download and install the CVMFS package"
 
 # Run the setup script
-cvmfs/test/cloud_testing/platforms/$setup_script $osx_name || usage "Couldn't execute the setup_script"
+cvmfs/test/cloud_testing/platforms/$CT_PLATFORM_SETUP_SCRIPT $osx_name || error "Couldn't execute the setup_script"
 
 # Run the test script
-cvmfs/test/cloud_testing/platforms/$run_script $osx_name || usage "Couldn't execute the run_script"
+cvmfs/test/cloud_testing/platforms/$CT_PLATFORM_RUN_SCRIPT $osx_name || error "Couldn't execute the run_script"

--- a/cvmfs/cloud_testing/run_remote_mac.sh
+++ b/cvmfs/cloud_testing/run_remote_mac.sh
@@ -20,6 +20,9 @@ echo "Printing environment " && env
 
 original_directory=$(pwd)
 
+# Create the workspace and the log directories
+mkdir -p "$cvmfs_workspace" "$cvmfs_log_directory"
+
 # Download and decompress the sources and install the client
 wget $source_tarball_url && tar xvf $source_name && mv cvmfs* cvmfs || usage "Couldn't download and decompress the sources in the mac VM"
 wget $client_package_url && cd / && sudo /usr/sbin/installer -pkg /Users/vagrant/$package_name -target / && cd $original_directory || usage "Couldn't download and install the CVMFS package"

--- a/cvmfs/cloud_testing/vagrant/provision_osx.sh
+++ b/cvmfs/cloud_testing/vagrant/provision_osx.sh
@@ -4,4 +4,4 @@
 set -e
 
 sudo -u vagrant brew update
-sudo -u vagrant brew install jq wget Caskroom/cask/osxfuse
+sudo -u vagrant brew install jq md5sha1sum wget Caskroom/cask/osxfuse

--- a/cvmfs/cloud_testing/vagrant/provision_osx.sh
+++ b/cvmfs/cloud_testing/vagrant/provision_osx.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+
+set -e
+
+sudo -u vagrant brew update
+sudo -u vagrant brew install jq wget Caskroom/cask/osxfuse

--- a/cvmfs/common.sh
+++ b/cvmfs/common.sh
@@ -25,7 +25,7 @@ has_platform_parameter() {
   local parameter="$1"
   local vm_description="$2"
   local result
-  result="$(echo -n "$vm_description" | jq --raw-output "has(\"$parameter\")")"
+  result=$(echo "$vm_description" | jq --raw-output "has(\"$parameter\")")
   [ x"$result" = x"true" ]
 }
 
@@ -35,7 +35,7 @@ get_platform_parameter() {
   if ! has_platform_parameter "$parameter" "$vm_description"; then
     echo ""
   else
-    echo -n "$vm_description" | jq --raw-output ".$parameter"
+    echo "$vm_description" | jq --raw-output ".$parameter"
   fi
 }
 

--- a/cvmfs/common.sh
+++ b/cvmfs/common.sh
@@ -39,6 +39,12 @@ get_platform_parameter() {
   fi
 }
 
+is_linux_vm() {
+  local ami=$1
+  echo "$ami" | grep -E "^ami-[0-9a-zA-Z]+$"
+  [ $? -eq 0 ]
+}
+
 # extracts an architecture string from a CI or build machine label such as:
 #   docker-i386
 #   bare-armv7hl

--- a/cvmfs/run_cloudtests.sh
+++ b/cvmfs/run_cloudtests.sh
@@ -26,26 +26,26 @@ has_platform_parameter 'ami'   "$vm_desc" || die "VM parameter .ami missing"
 has_platform_parameter 'user'  "$vm_desc" || die "VM parameter .user missing"
 
 # exports for scripts in mac and linux
-export testee_url="$CVMFS_TESTEE_URL"
-export client_testee_url="$CVMFS_CLIENT_TESTEE_URL"
-export platform=$(get_platform_parameter 'label'   "$vm_desc")
-export platform_setup_script=$(get_platform_parameter 'setup'   "$vm_desc")
-export platform_run_script=$(get_platform_parameter 'test'    "$vm_desc")
-export ec2_config="$EC2_CONFIG"
-export ami_name=$(get_platform_parameter 'ami'     "$vm_desc")
-export username=$(get_platform_parameter 'user'    "$vm_desc")
-export userdata=$(get_platform_parameter 'context' "$vm_desc")
-export source_tarball="source.tar.gz"
+export CT_TESTEE_URL="$CVMFS_TESTEE_URL"
+export CT_CLIENT_TESTEE_URL="$CVMFS_CLIENT_TESTEE_URL"
+export CT_PLATFORM=$(get_platform_parameter 'label'   "$vm_desc")
+export CT_PLATFORM_SETUP_SCRIPT=$(get_platform_parameter 'setup'   "$vm_desc")
+export CT_PLATFORM_RUN_SCRIPT=$(get_platform_parameter 'test'    "$vm_desc")
+export CT_EC2_CONFIG="$EC2_CONFIG"
+export CT_AMI_NAME=$(get_platform_parameter 'ami'     "$vm_desc")
+export CT_USERNAME=$(get_platform_parameter 'user'    "$vm_desc")
+export CT_USERDATA=$(get_platform_parameter 'context' "$vm_desc")
+export CT_SOURCE_TARBALL="source.tar.gz"
 
 # static information (check also remote_setup.sh and remote_run.sh)
-export cvmfs_workspace="/tmp/cvmfs-test-workspace"
-export cvmfs_log_directory="${cvmfs_workspace}/logs"
+export CT_CVMFS_WORKSPACE="/tmp/cvmfs-test-workspace"
+export CT_CVMFS_LOG_DIRECTORY="${CT_CVMFS_WORKSPACE}/logs"
 
 
-echo "Running cloud tests for $CVMFS_PLATFORM / $CVMFS_PLATFORM_CONFIG ..."
+echo "Running cloud tests for $CT_CVMFS_PLATFORM / $CVMFS_PLATFORM_CONFIG ..."
 
 # if we are on mac then we have to run an special script
-if [ ! $(is_linux_vm $ami_name) ]; then
+if [ ! $(is_linux_vm $CT_AMI_NAME) ]; then
   ${SCRIPT_LOCATION}/cloud_testing/run_mac.sh
 else
   ${SCRIPT_LOCATION}/cloud_testing/run.sh

--- a/cvmfs/run_cloudtests.sh
+++ b/cvmfs/run_cloudtests.sh
@@ -25,14 +25,23 @@ has_platform_parameter 'test'  "$vm_desc" || die "VM parameter .test missing"
 has_platform_parameter 'ami'   "$vm_desc" || die "VM parameter .ami missing"
 has_platform_parameter 'user'  "$vm_desc" || die "VM parameter .user missing"
 
+export testee_url="$CVMFS_TESTEE_URL"
+export client_testee_url="$CVMFS_CLIENT_TESTEE_URL"
+export platform=$(get_platform_parameter 'label'   "$vm_desc")
+export platform_setup_script=$(get_platform_parameter 'setup'   "$vm_desc")
+export platform_run_script=$(get_platform_parameter 'test'    "$vm_desc")
+export ec2_config="$EC2_CONFIG"
+export ami_name=$(get_platform_parameter 'ami'     "$vm_desc")
+export username=$(get_platform_parameter 'user'    "$vm_desc")
+export userdata=$(get_platform_parameter 'context' "$vm_desc")
+export source_tarball="source.tar.gz"
+
+
 echo "Running cloud tests for $CVMFS_PLATFORM / $CVMFS_PLATFORM_CONFIG ..."
-${SCRIPT_LOCATION}/cloud_testing/run.sh                    \
-        -u $CVMFS_TESTEE_URL                               \
-        -p  $(get_platform_parameter 'label'   "$vm_desc") \
-        -b  $(get_platform_parameter 'setup'   "$vm_desc") \
-        -r  $(get_platform_parameter 'test'    "$vm_desc") \
-        -e $EC2_CONFIG                                     \
-        -a  $(get_platform_parameter 'ami'     "$vm_desc") \
-        -m  $(get_platform_parameter 'user'    "$vm_desc") \
-        -c "$(get_platform_parameter 'context' "$vm_desc")"\
-        -l "$CVMFS_CLIENT_TESTEE_URL"
+
+# if we are on mac then we have to run an special script
+if [ ! $(is_linux_vm $ami_name) ]; then
+  ${SCRIPT_LOCATION}/cloud_testing/run_mac.sh
+else
+  ${SCRIPT_LOCATION}/cloud_testing/run.sh
+fi

--- a/cvmfs/run_cloudtests.sh
+++ b/cvmfs/run_cloudtests.sh
@@ -25,6 +25,7 @@ has_platform_parameter 'test'  "$vm_desc" || die "VM parameter .test missing"
 has_platform_parameter 'ami'   "$vm_desc" || die "VM parameter .ami missing"
 has_platform_parameter 'user'  "$vm_desc" || die "VM parameter .user missing"
 
+# exports for scripts in mac and linux
 export testee_url="$CVMFS_TESTEE_URL"
 export client_testee_url="$CVMFS_CLIENT_TESTEE_URL"
 export platform=$(get_platform_parameter 'label'   "$vm_desc")
@@ -35,6 +36,10 @@ export ami_name=$(get_platform_parameter 'ami'     "$vm_desc")
 export username=$(get_platform_parameter 'user'    "$vm_desc")
 export userdata=$(get_platform_parameter 'context' "$vm_desc")
 export source_tarball="source.tar.gz"
+
+# static information (check also remote_setup.sh and remote_run.sh)
+export cvmfs_workspace="/tmp/cvmfs-test-workspace"
+export cvmfs_log_directory="${cvmfs_workspace}/logs"
 
 
 echo "Running cloud tests for $CVMFS_PLATFORM / $CVMFS_PLATFORM_CONFIG ..."

--- a/cvmfs/run_cloudtests.sh
+++ b/cvmfs/run_cloudtests.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
 . ${SCRIPT_LOCATION}/../jenkins/common.sh
@@ -42,7 +43,7 @@ export CT_CVMFS_WORKSPACE="/tmp/cvmfs-test-workspace"
 export CT_CVMFS_LOG_DIRECTORY="${CT_CVMFS_WORKSPACE}/logs"
 
 
-echo "Running cloud tests for $CT_CVMFS_PLATFORM / $CVMFS_PLATFORM_CONFIG ..."
+echo "Running cloud tests for $CT_PLATFORM / $CVMFS_PLATFORM_CONFIG ..."
 
 # if we are on mac then we have to run an special script
 if [ ! $(is_linux_vm $CT_AMI_NAME) ]; then


### PR DESCRIPTION
This PR is meant to have a special supervision because it changes and adds a significant amount of code. Concretely:
- Creates a new script called run_mac.sh that is called from run.sh after parsing the parameters and executes the integration tests in a mac virtual machine through a mac host using vagrant.
- The consequent Vagrant files had to be added in order to boot the mac VM
- plaforms.json updated with the new mac platform
- This PR relies on the changes in https://github.com/cvmfs/cvmfs/pull/1300
