### PR TITLE
Workaround: Docker Deamon Choking on massive stdout/stderr

### DIFF
--- a/docker/docker_script_wrapper.sh
+++ b/docker/docker_script_wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#
+# Workaround: Producing a lot of output on stdout/stderr produces hiccups inside
+#             the docker deamon. Apparently docker is aware of it, but it still
+#             seems to happen [1].
+#
+#   [1] https://github.com/docker/docker/issues/14460
+#
+# This wrapper script is working around this issue by piping stdout and stderr
+# through files inside a mounted docker volume.
+#
+
+die() {
+  echo "$1" >&2
+  exit 1
+}
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 <stdout file> <stderr file> <command>"
+  exit 1
+fi
+
+fstdout="$1"
+fstderr="$2"
+shift 2
+
+[ -f $fstdout ] || touch $fstdout || die "cannot find or create $fstdout"
+[ -f $fstderr ] || touch $fstderr || die "cannot find or create $fstderr"
+
+"$@" >> $fstdout 2>>$fstderr

--- a/docker/run_on_docker.sh
+++ b/docker/run_on_docker.sh
@@ -20,8 +20,6 @@ if [ $# -lt 3 ]; then
   exit 1
 fi
 
-set -x
-
 WORKSPACE="$1"
 CVMFS_DOCKER_IMAGE="$2"
 shift 2

--- a/docker/run_on_docker.sh
+++ b/docker/run_on_docker.sh
@@ -143,13 +143,18 @@ for var in $(env | grep -e "^\(CVMFS\|CERNVM\)_.*\$"); do
 done
 
 # run provided script inside the docker container
+# Note: Workaround for stdout/stderr redirection in conjunction with
+#       docker_script_wrapper.sh
 uid=$(id -u)
 gid=$(id -g)
 echo "++ $@"
-sudo docker run --volume="$WORKSPACE":"$WORKSPACE"      \
-                --volume=/etc/passwd:/etc/passwd        \
-                --volume=/etc/group:/etc/group          \
-                --user=${uid}:${gid}                    \
-                --rm=true                               \
-                --privileged=true                       \
-                $args $image_name "$@"
+sudo docker run --volume="$WORKSPACE":"$WORKSPACE"           \
+                --volume=/etc/passwd:/etc/passwd             \
+                --volume=/etc/group:/etc/group               \
+                --volume="$OUTPUT_POOL_DIR:$OUTPUT_POOL_DIR" \
+                --user=${uid}:${gid}                         \
+                --rm=true                                    \
+                --privileged=true                            \
+                $args $image_name                            \
+                ${OUTPUT_POOL_DIR}/docker_script_wrapper.sh  \
+                $fstdout $fstderr "$@"


### PR DESCRIPTION
This works around an issue in the docker daemon - namely that it chokes on large amounts of data through stdout/stderr. This redirects outputs of the payload-command through files inside a mounted volume using a wrapper script (i.e. `docker_script_wrapper.sh`) that is started by `run_on_docker.sh`.