### PR TITLE
CVM-1325

### DIFF
--- a/docker/images/cc7_x86_64/Dockerfile
+++ b/docker/images/cc7_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         cc7_x86_64.tar.gz /

--- a/docker/images/debian8_x86_64/Dockerfile
+++ b/docker/images/debian8_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         debian8_x86_64.tar.gz /

--- a/docker/images/fedora21_i386/Dockerfile
+++ b/docker/images/fedora21_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora21_i386.tar.gz /

--- a/docker/images/fedora21_x86_64/Dockerfile
+++ b/docker/images/fedora21_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora21_x86_64.tar.gz /

--- a/docker/images/fedora22_i386/Dockerfile
+++ b/docker/images/fedora22_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora22_i386.tar.gz /

--- a/docker/images/fedora22_x86_64/Dockerfile
+++ b/docker/images/fedora22_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora22_x86_64.tar.gz /

--- a/docker/images/fedora23_i386/Dockerfile
+++ b/docker/images/fedora23_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora23_i386.tar.gz /

--- a/docker/images/fedora23_x86_64/Dockerfile
+++ b/docker/images/fedora23_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         fedora23_x86_64.tar.gz /

--- a/docker/images/fedora24_i386/Dockerfile
+++ b/docker/images/fedora24_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         fedora24_i386.tar.gz /

--- a/docker/images/fedora24_x86_64/Dockerfile
+++ b/docker/images/fedora24_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         fedora24_x86_64.tar.gz /

--- a/docker/images/opensuse13_x86_64/Dockerfile
+++ b/docker/images/opensuse13_x86_64/Dockerfile
@@ -1,6 +1,6 @@
 ## See README.md, build.sh and ../build_on_docker.sh
 
-FROM       scratch
+FROM       cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER Rene Meusel <rene.meusel@cern.ch>
 
 ADD        opensuse13_x86_64.tar.gz /

--- a/docker/images/slc4_i386/Dockerfile
+++ b/docker/images/slc4_i386/Dockerfile
@@ -1,6 +1,6 @@
 ## See README.md, build.sh and ../build_on_docker.sh
 
-FROM       scratch
+FROM       cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER Rene Meusel <rene.meusel@cern.ch>
 
 ADD        slc4_i386.tar.gz /

--- a/docker/images/slc5_i386/Dockerfile
+++ b/docker/images/slc5_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc5_i386.tar.gz /

--- a/docker/images/slc5_x86_64/Dockerfile
+++ b/docker/images/slc5_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc5_x86_64.tar.gz /

--- a/docker/images/slc6_i386/Dockerfile
+++ b/docker/images/slc6_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc6_i386.tar.gz /

--- a/docker/images/slc6_x86_64/Dockerfile
+++ b/docker/images/slc6_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         slc6_x86_64.tar.gz /

--- a/docker/images/sles11_x86_64/Dockerfile
+++ b/docker/images/sles11_x86_64/Dockerfile
@@ -1,6 +1,6 @@
 ## See README.md, build.sh and ../build_on_docker.sh
 
-FROM       scratch
+FROM       cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER Rene Meusel <rene.meusel@cern.ch>
 
 ADD        sles11_x86_64.tar.gz /

--- a/docker/images/sles12_x86_64/Dockerfile
+++ b/docker/images/sles12_x86_64/Dockerfile
@@ -1,6 +1,6 @@
 ## See README.md, build.sh and ../build_on_docker.sh
 
-FROM       scratch
+FROM       cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER Jakob Blomer <jblomer@cern.ch>
 
 ADD        sles12_x86_64.tar.gz /

--- a/docker/images/ubuntu1204_i386/Dockerfile
+++ b/docker/images/ubuntu1204_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         ubuntu1204_i386.tar.gz /

--- a/docker/images/ubuntu1204_x86_64/Dockerfile
+++ b/docker/images/ubuntu1204_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         ubuntu1204_x86_64.tar.gz /

--- a/docker/images/ubuntu1404_i386/Dockerfile
+++ b/docker/images/ubuntu1404_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Rene Meusel <rene.meusel@cern.ch>
 
 ADD         ubuntu1404_i386.tar.gz /

--- a/docker/images/ubuntu1404_x86_64/Dockerfile
+++ b/docker/images/ubuntu1404_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         ubuntu1404_x86_64.tar.gz /

--- a/docker/images/ubuntu1604_i386/Dockerfile
+++ b/docker/images/ubuntu1604_i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         ubuntu1604_i386.tar.gz /

--- a/docker/images/ubuntu1604_x86_64/Dockerfile
+++ b/docker/images/ubuntu1604_x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM        scratch
+FROM        cvm-dockerhub03.cern.ch/thin_scratch
 MAINTAINER  Jakob Blomer <jblomer@cern.ch>
 
 ADD         ubuntu1604_x86_64.tar.gz /

--- a/docker/run_on_docker.sh
+++ b/docker/run_on_docker.sh
@@ -21,7 +21,7 @@ if [ $# -lt 3 ]; then
 fi
 
 WORKSPACE="$1"
-CVMFS_DOCKER_IMAGE="$2"
+CVMFS_DOCKER_IMAGE="$(echo $2 | sed 's/-test$//')"
 shift 2
 
 # retrieves the image creation time of a docker image in epoch

--- a/docker/run_on_docker.sh
+++ b/docker/run_on_docker.sh
@@ -109,7 +109,7 @@ which docker > /dev/null 2>&1 || die "docker is not installed"
 which git    > /dev/null 2>&1 || die "git is not installed"
 
 # check if the docker container specification exists in ci/docker
-image_name="cvmfs-dockerhub03.cern.ch/${CVMFS_DOCKER_IMAGE}"
+image_name="cvm-dockerhub03.cern.ch/${CVMFS_DOCKER_IMAGE}"
 container_dir="${SCRIPT_LOCATION}/images/${CVMFS_DOCKER_IMAGE}"
 [ -d $container_dir ] || die "container $CVMFS_DOCKER_IMAGE not found"
 


### PR DESCRIPTION
This pull request introduces following changes:
- Docker images can be shared between the build nodes via private Docker registry (dockerhub03)
- Dockerfiles for build containers are based on the `thin_scratch` image to trigger the cvmfs graphdriver plug-in

Following assumptions were made:
- `cvm-dockerhub03.cern.ch` is hosting a private Docker registry + Minio S3 and "CVMFS publisher script"
- The `thin_scratch` image is published in the `cvm-dockerhub03.cern.ch` Docker repository
- The name of the Docker repository is changed from `cvmfs` to `cvm-dockerhub03.cern.ch`

This setup can work in fallback mode in two ways but both assume that `cvm-dockerhub03.cern.ch/thin_scratch` exists either as a thin image or re-tagged normal scratch (empty) Docker image.

1. If the cvmfs graphdriver plug-in is in use and `thin_scratch` is regular image, then the graphdriver will not publish layers to CVMFS and an ordinary Docker image will be built.

1. If a standard graphdriver is in use and `thin_scratch` is either normal or thin image, then an ordinary Docker image will be built.