### PR TITLE
Use new CentOS 7 image

### DIFF
--- a/cvmfs/cloud_testing/platforms.json
+++ b/cvmfs/cloud_testing/platforms.json
@@ -83,7 +83,7 @@
   {
     "dist": "el7",
     "config": "x86_64",
-    "ami": "ami-2b1e8c87",
+    "ami": "ami-2170c9fc",
     "label": "cc7_x86_64",
     "setup": "centos7_x86_64_setup.sh",
     "test": "centos7_x86_64_test.sh",
@@ -95,7 +95,7 @@
   {
     "dist": "el7",
     "config": "x86_64_s3",
-    "ami": "ami-2b1e8c87",
+    "ami": "ami-2170c9fc",
     "label": "cc7_x86_64",
     "setup": "centos7_x86_64_setup.sh",
     "test": "centos7_x86_64_s3_test.sh",
@@ -107,7 +107,7 @@
   {
     "dist": "el7",
     "config": "x86_64_ramcache",
-    "ami": "ami-2b1e8c87",
+    "ami": "ami-2170c9fc",
     "label": "cc7_x86_64",
     "setup": "centos7_x86_64-RAMCACHE_setup.sh",
     "test": "centos7_x86_64-RAMCACHE_test.sh",
@@ -119,7 +119,7 @@
   {
     "dist": "el7",
     "config": "x86_64_nfs",
-    "ami": "ami-2b1e8c87",
+    "ami": "ami-2170c9fc",
     "label": "cc7_x86_64",
     "setup": "centos7_x86_64-NFS_setup.sh",
     "test": "centos7_x86_64-NFS_test.sh",


### PR DESCRIPTION
The previous CentOS 7 image seems to have disappeared from the CERN Openstack registry.
Re-uploading the official CentOS 7 cloud image to use with the integration tests.